### PR TITLE
Fixing logic around evaluating SourceFilePath in LogSource constructor

### DIFF
--- a/src/Dapplo.Log.Tests/LoggerTests.cs
+++ b/src/Dapplo.Log.Tests/LoggerTests.cs
@@ -44,6 +44,34 @@ namespace Dapplo.Log.Tests
         }
 
         [Fact]
+        public void TestConstructorWithLinuxPath()
+        {
+            var log = new LogSource("/Some/Path/To/Namespace/Type.Name.dll");
+            Assert.Equal("Namespace.Type.Name", log.Source);
+        }
+        
+        [Fact]
+        public void TestConstructorWithWindowsPath()
+        {
+            var log = new LogSource(@"c:\Some\Path\To\Namespace\Type.Name.dll");
+            Assert.Equal("Namespace.Type.Name", log.Source);
+        }
+        
+        [Fact]
+        public void TestConstructorWithShortLinuxPath()
+        {
+            var log = new LogSource("/Namespace/Type.Name.dll");
+            Assert.Equal("Namespace.Type.Name", log.Source);
+        }
+        
+        [Fact]
+        public void TestConstructorWithShortWindowsPath()
+        {
+            var log = new LogSource(@"c:\Namespace\Type.Name.dll");
+            Assert.Equal("Namespace.Type.Name", log.Source);
+        }
+
+        [Fact]
         public void TestRegisterDefaultLogger()
         {
             var defaultLogger = LogSettings.DefaultLogger;

--- a/src/Dapplo.Log/LogSource.cs
+++ b/src/Dapplo.Log/LogSource.cs
@@ -1,4 +1,4 @@
-﻿#region Dapplo 2016-2019 - GNU Lesser General Public License
+#region Dapplo 2016-2019 - GNU Lesser General Public License
 
 // Dapplo - building blocks for .NET applications
 // Copyright (C) 2016-2019 Dapplo
@@ -27,12 +27,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-#if NETSTANDARD2_0 || NETSTANDARD1_3 || NET45
-using System.IO;
-#endif
-#if NETSTANDARD1_1
-using System.Runtime.InteropServices;
-#endif
 
 namespace Dapplo.Log
 {
@@ -143,7 +137,8 @@ namespace Dapplo.Log
         private void SetSourceFromString(string source)
         {
             Source = source;
-            var parts = Source.Split(Dot);            if (parts.Length > 0)
+            var parts = Source.Split(Dot);
+            if (parts.Length > 0)
             {
                 ShortSource = string.Join(".", parts.Take(parts.Length - 1).Select(s => s.Substring(0, 1).ToLowerInvariant()).Concat(new[] {parts.Last()}));
             }

--- a/src/Dapplo.Log/LogSource.cs
+++ b/src/Dapplo.Log/LogSource.cs
@@ -100,14 +100,8 @@ namespace Dapplo.Log
                 throw new ArgumentNullException(nameof(sourceFilePath));
             }
 
-#if NETSTANDARD2_0 || NETSTANDARD1_3 || NET45
-            var directorySeparatorChar = Path.DirectorySeparatorChar;
-#elif NETSTANDARD1_1
-            var directorySeparatorChar = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '\\' : '/';
-#else
-            const char directorySeparatorChar = '\\';
-#endif
-
+            var directorySeparatorChar = sourceFilePath.IndexOf('/') >= 0 ? '/' : '\\';
+            
             var pathParts = sourceFilePath.Split(directorySeparatorChar);
 
             var typeName = GetFilenameWithoutExtension(pathParts);


### PR DESCRIPTION
Replacing path logic dependent on Runtime o/s with something based upon the content of the supplied string (default value of [CallerFilePath] is compile-time generated)

Resolves #5 